### PR TITLE
feat: add item detail page (/objetos/:id)

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -224,6 +224,38 @@ app.get("/api/compendium-items", async (req, res) => {
 	}
 });
 
+// 🆕 Endpoint: obtener un item específico por ID (UUID o slug SRD)
+app.get("/api/compendium-items/:id", async (req, res) => {
+	try {
+		const { id } = req.params;
+		const isUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id);
+
+		let query = supabase.from("compendium_items").select("*");
+		if (isUUID) {
+			query = query.eq("id", id);
+		} else {
+			// Buscar por el campo index dentro del JSONB stats
+			query = query.filter("stats->>index", "eq", id);
+		}
+
+		const { data, error } = await query.single();
+
+		if (error || !data) {
+			return res.status(404).json({
+				error: "Item no encontrado",
+				details: error?.message,
+			});
+		}
+
+		res.json(data);
+	} catch (err) {
+		res.status(500).json({
+			error: "Error interno",
+			details: err.message,
+		});
+	}
+});
+
 // 🆕 Endpoint: obtener todos los hechizos
 app.get("/api/compendium-spells", async (req, res) => {
 	try {

--- a/frontend/src/core/api/backend.service.ts
+++ b/frontend/src/core/api/backend.service.ts
@@ -119,6 +119,19 @@ export async function fetchItems(): Promise<ItemsResponse> {
   return response.json();
 }
 
+/**
+ * Obtiene un item específico por ID
+ */
+export async function fetchItemById(id: string): Promise<Item> {
+  const response = await fetch(`${BACKEND_URL}/api/compendium-items/${id}`);
+  
+  if (!response.ok) {
+    throw new Error(`Error ${response.status}: ${response.statusText}`);
+  }
+  
+  return response.json();
+}
+
 // ============================================
 // SPELLS
 // ============================================

--- a/frontend/src/pods/partida/components/inventory/components/BagSection.tsx
+++ b/frontend/src/pods/partida/components/inventory/components/BagSection.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import type { BagItem, CompendiumItem } from "../types";
 import { AutocompleteInput } from "./AutocompleteInput";
 
@@ -39,14 +40,14 @@ export function BagSection({
               <div className="flex items-center justify-between gap-2">
                 <div className="flex-1 min-w-0">
                   {item.srdIndex ? (
-                    <a
-                      href={`/objetos?q=${encodeURIComponent(item.name)}`}
+                    <Link
+                      to={`/objetos/${item.srdIndex}`}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="text-amber-100 truncate block hover:text-amber-300 hover:underline"
                     >
                       {item.name}
-                    </a>
+                    </Link>
                   ) : (
                     <span
                       className={`truncate block ${item.tags?.includes("CUSTOM") ? "text-amber-100/80 italic" : "text-amber-100"}`}

--- a/frontend/src/pods/partida/components/inventory/components/ConsumableSection.tsx
+++ b/frontend/src/pods/partida/components/inventory/components/ConsumableSection.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import type { ConsumableItem, CompendiumItem } from "../types";
 import { AutocompleteInput } from "./AutocompleteInput";
 
@@ -42,14 +43,14 @@ export function ConsumableSection({
           >
             <div className="flex items-center justify-between gap-2">
               {item.srdIndex ? (
-                <a
-                  href={`/objetos?q=${encodeURIComponent(item.name)}`}
+                <Link
+                  to={`/objetos/${item.srdIndex}`}
                   target="_blank"
                   rel="noopener noreferrer"
                   className="text-amber-100 truncate flex-1 hover:text-amber-300 hover:underline"
                 >
                   {item.name}
-                </a>
+                </Link>
               ) : (
                 <span
                   className={`truncate flex-1 ${item.tags?.includes("CUSTOM") ? "text-amber-100/80 italic" : "text-amber-100"}`}

--- a/frontend/src/router/app.router.tsx
+++ b/frontend/src/router/app.router.tsx
@@ -20,6 +20,7 @@ import InventarioScene from "@/scenes/inventario.scene";
 import BestiarioScene from "@/scenes/bestiario.scene";
 import BestiarioDetalleScene from "@/scenes/bestiario-detalle.scene";
 import ObjetosScene from "@/scenes/objetos.scene";
+import ObjetosDetalleScene from "@/scenes/objetos-detalle.scene";
 import { ProtectedRoute } from "@/core/auth/ProtectedRoute";
 import { AppLayout } from "@/layout/app.layout";
 import { FullscreenToolLayout } from "@/layout/tool.layout";
@@ -40,6 +41,7 @@ export const AppRouter = () => {
 				<Route path={switchRoutes.bestiario} element={<AppLayout><BestiarioScene /></AppLayout>} />
 				<Route path={switchRoutes.bestiarioDetalle} element={<AppLayout><BestiarioDetalleScene /></AppLayout>} />
 				<Route path={switchRoutes.objetos} element={<AppLayout><ObjetosScene /></AppLayout>} />
+				<Route path={switchRoutes.objetosDetalle} element={<AppLayout><ObjetosDetalleScene /></AppLayout>} />
 				<Route path={switchRoutes.dados} element={<AppLayout><DadosScene /></AppLayout>} />
 				<Route path={switchRoutes.inventario} element={<AppLayout><InventarioScene /></AppLayout>} />
 				<Route path={switchRoutes.fichas} element={<AppLayout><MisFichasScene /></AppLayout>} />

--- a/frontend/src/router/routes.ts
+++ b/frontend/src/router/routes.ts
@@ -15,6 +15,7 @@ interface SwitchRoutes {
 	dados: string;
 	inventario: string;
 	objetos: string;
+	objetosDetalle: string;
 	mapaBatalla: string;
 	editarCampana: string;
 	partida: string;
@@ -38,6 +39,7 @@ export const switchRoutes: SwitchRoutes = {
 	dados: "/dados",
 	inventario: "/inventario",
 	objetos: "/objetos",
+	objetosDetalle: "/objetos/:id",
 	mapaBatalla: "/mapa-batalla",
 	editarCampana: "/editar-campana/:id",
 	partida: "/partida/:id",

--- a/frontend/src/scenes/inventario.scene.tsx
+++ b/frontend/src/scenes/inventario.scene.tsx
@@ -1,4 +1,4 @@
-﻿import { useState, useEffect, useRef, useMemo } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { Link } from "react-router-dom";
 import { useAuth } from "@/core/auth/useAuth";
 import { Button } from "@/components/ui/button";
@@ -742,14 +742,14 @@ function ConsumableSection({
 					>
 						<div className="flex items-center justify-between gap-2">
 							{item.srdIndex ? (
-								<a
-									href={`/objetos?q=${encodeURIComponent(item.name)}`}
+								<Link
+									to={`/objetos/${item.srdIndex}`}
 									target="_blank"
 									rel="noopener noreferrer"
 									className="text-amber-100 truncate flex-1 hover:text-amber-300 hover:underline"
 								>
 									{item.name}
-								</a>
+								</Link>
 							) : (
 								<span
 									className={`truncate flex-1 ${item.tags?.includes("CUSTOM") ? "text-amber-100/80 italic" : "text-amber-100"}`}
@@ -851,14 +851,14 @@ function BagSection({
 							<div className="flex items-center justify-between gap-2">
 								<div className="flex-1 min-w-0">
 									{item.srdIndex ? (
-										<a
-											href={`/objetos?q=${encodeURIComponent(item.name)}`}
+										<Link
+											to={`/objetos/${item.srdIndex}`}
 											target="_blank"
 											rel="noopener noreferrer"
 											className="text-amber-100 truncate block hover:text-amber-300 hover:underline"
 										>
 											{item.name}
-										</a>
+										</Link>
 									) : (
 										<span
 											className={`truncate block ${item.tags?.includes("CUSTOM") ? "text-amber-100/80 italic" : "text-amber-100"}`}

--- a/frontend/src/scenes/objetos-detalle.scene.tsx
+++ b/frontend/src/scenes/objetos-detalle.scene.tsx
@@ -1,0 +1,319 @@
+import { useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { routes } from "@/router";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Loader2, AlertCircle, ArrowLeft, Package } from "lucide-react";
+import { fetchItemById, type Item } from "@/core/api/backend.service";
+
+const formatCost = (cost: any) => {
+	if (!cost) return null;
+	if (typeof cost === "object" && cost.quantity !== undefined && cost.unit) {
+		return `${cost.quantity} ${cost.unit}`;
+	}
+	return String(cost);
+};
+
+const getCategoryColor = (category: any) => {
+	if (!category) return "bg-gray-600";
+	const name = typeof category === "object" ? category.name : category;
+	const lower = name?.toLowerCase() || "";
+	if (lower.includes("weapon")) return "bg-red-600";
+	if (lower.includes("armor")) return "bg-blue-600";
+	if (lower.includes("potion")) return "bg-purple-600";
+	if (lower.includes("tool")) return "bg-yellow-600";
+	return "bg-gray-600";
+};
+
+const ObjetosDetalleScene = () => {
+	const { id } = useParams<{ id: string }>();
+	const navigate = useNavigate();
+	const [item, setItem] = useState<Item | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		if (id) loadItem(id);
+	}, [id]);
+
+	const loadItem = async (itemId: string) => {
+		try {
+			setLoading(true);
+			setError(null);
+			const data = await fetchItemById(itemId);
+			const stats = data.stats || {};
+			const normalized: Item = {
+				...data,
+				equipment_category: stats.equipment_category || data.equipment_category,
+				cost: stats.cost || data.cost,
+				weight: stats.weight ?? data.weight,
+				damage: stats.damage || data.damage,
+				two_handed_damage: stats.two_handed_damage || data.two_handed_damage,
+				armor_class: stats.armor_class || data.armor_class,
+				properties: stats.properties || data.properties,
+				desc: stats.desc || data.desc,
+				range: stats.range || data.range,
+				throw_range: stats.throw_range || data.throw_range,
+				str_minimum: stats.str_minimum ?? data.str_minimum,
+				stealth_disadvantage:
+					stats.stealth_disadvantage ?? data.stealth_disadvantage,
+				weapon_category: stats.weapon_category || data.weapon_category,
+				weapon_range: stats.weapon_range || data.weapon_range,
+				armor_category: stats.armor_category || data.armor_category,
+			};
+			setItem(normalized);
+		} catch (err) {
+			console.error("Error al cargar objeto:", err);
+			setError(
+				err instanceof Error
+					? err.message
+					: "No se pudo cargar el objeto. Verifica que el backend esté corriendo.",
+			);
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	if (loading) {
+		return (
+			<div className="container mx-auto p-6 flex flex-col items-center justify-center py-12 gap-4">
+				<Loader2 className="h-12 w-12 animate-spin text-amber-500" />
+				<p className="text-sm text-gray-400">Cargando objeto...</p>
+			</div>
+		);
+	}
+
+	if (error || !item) {
+		return (
+			<div className="container mx-auto p-6 max-w-7xl space-y-6">
+				<Button
+					onClick={() => navigate(routes.objetos)}
+					variant="outline"
+					className="gap-2"
+				>
+					<ArrowLeft className="h-4 w-4" />
+					Volver a Objetos
+				</Button>
+				<Alert
+					variant="destructive"
+					className="bg-red-950/50 border-red-900"
+				>
+					<AlertCircle className="h-4 w-4" />
+					<AlertDescription className="text-red-200">
+						{error || "Objeto no encontrado"}
+					</AlertDescription>
+				</Alert>
+			</div>
+		);
+	}
+
+	const categoryName =
+		typeof item.equipment_category === "object"
+			? item.equipment_category?.name
+			: item.equipment_category;
+
+	return (
+		<div className="container mx-auto p-6 max-w-7xl space-y-6">
+			<Button
+				onClick={() => navigate(routes.objetos)}
+				variant="outline"
+				className="gap-2 border-amber-600/30 text-amber-200 hover:bg-amber-950/30 hover:text-amber-100"
+			>
+				<ArrowLeft className="h-4 w-4" />
+				Volver a Objetos
+			</Button>
+
+			{/* Header */}
+			<section className="rounded-2xl bg-gradient-to-r from-amber-600/30 via-yellow-500/20 to-amber-600/30 p-6 shadow-xl border border-amber-600/20">
+				<div className="flex items-center gap-3 mb-2">
+					<Package className="h-8 w-8 text-amber-200" />
+					<h1 className="text-3xl font-extrabold text-amber-50">{item.name}</h1>
+					{categoryName && (
+						<Badge
+							className={`${getCategoryColor(item.equipment_category)} text-white text-sm px-3 py-1`}
+						>
+							{categoryName}
+						</Badge>
+					)}
+				</div>
+				<div className="flex flex-wrap gap-2 mt-3">
+					{item.weapon_category && (
+						<Badge
+							variant="outline"
+							className="bg-red-950/50 border-red-600/50 text-red-300"
+						>
+							{item.weapon_category}
+						</Badge>
+					)}
+					{item.armor_category && (
+						<Badge
+							variant="outline"
+							className="bg-blue-950/50 border-blue-600/50 text-blue-300"
+						>
+							{item.armor_category}
+						</Badge>
+					)}
+					{item.stealth_disadvantage && (
+						<Badge
+							variant="outline"
+							className="bg-gray-800/50 border-gray-600/50 text-gray-300"
+						>
+							Desventaja en Sigilo
+						</Badge>
+					)}
+				</div>
+			</section>
+
+			{/* Stats */}
+			<Card className="bg-dark-card border-dark-border">
+				<CardHeader>
+					<CardTitle className="text-amber-100">Características</CardTitle>
+				</CardHeader>
+				<CardContent className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+					{item.cost && (
+						<div className="flex flex-col">
+							<span className="text-xs text-gray-400 uppercase">Coste</span>
+							<span className="text-lg font-semibold text-amber-200">
+								{formatCost(item.cost)}
+							</span>
+						</div>
+					)}
+					{item.weight !== undefined && (
+						<div className="flex flex-col">
+							<span className="text-xs text-gray-400 uppercase">Peso</span>
+							<span className="text-lg font-semibold text-amber-200">
+								{item.weight} lb
+							</span>
+						</div>
+					)}
+					{item.damage && (
+						<div className="flex flex-col">
+							<span className="text-xs text-gray-400 uppercase">Daño</span>
+							<span className="text-lg font-semibold text-amber-200">
+								{item.damage.damage_dice}{" "}
+								{item.damage.damage_type?.name
+									? `(${item.damage.damage_type.name})`
+									: ""}
+							</span>
+						</div>
+					)}
+					{item.two_handed_damage && (
+						<div className="flex flex-col">
+							<span className="text-xs text-gray-400 uppercase">
+								Daño (2 manos)
+							</span>
+							<span className="text-lg font-semibold text-amber-200">
+								{item.two_handed_damage.damage_dice}{" "}
+								{item.two_handed_damage.damage_type?.name
+									? `(${item.two_handed_damage.damage_type.name})`
+									: ""}
+							</span>
+						</div>
+					)}
+					{item.armor_class && (
+						<div className="flex flex-col">
+							<span className="text-xs text-gray-400 uppercase">
+								Clase de Armadura
+							</span>
+							<span className="text-lg font-semibold text-amber-200">
+								{typeof item.armor_class === "object"
+									? item.armor_class.base ||
+										item.armor_class.value ||
+										JSON.stringify(item.armor_class)
+									: item.armor_class}
+								{item.armor_class?.dex_bonus ? " + Mod. DES" : ""}
+							</span>
+						</div>
+					)}
+					{item.str_minimum ? (
+						<div className="flex flex-col">
+							<span className="text-xs text-gray-400 uppercase">
+								FUE mínima
+							</span>
+							<span className="text-lg font-semibold text-amber-200">
+								{item.str_minimum}
+							</span>
+						</div>
+					) : null}
+					{item.range && (
+						<div className="flex flex-col">
+							<span className="text-xs text-gray-400 uppercase">Alcance</span>
+							<span className="text-lg font-semibold text-amber-200">
+								{typeof item.range === "object" &&
+								item.range.normal !== undefined
+									? `${item.range.normal} ft${item.range.long ? ` / ${item.range.long} ft` : ""}`
+									: String(item.range)}
+							</span>
+						</div>
+					)}
+					{item.throw_range && (
+						<div className="flex flex-col">
+							<span className="text-xs text-gray-400 uppercase">
+								Alcance de Lanzamiento
+							</span>
+							<span className="text-lg font-semibold text-amber-200">
+								{typeof item.throw_range === "object"
+									? `${item.throw_range.normal} ft / ${item.throw_range.long} ft`
+									: String(item.throw_range)}
+							</span>
+						</div>
+					)}
+					{item.weapon_range && (
+						<div className="flex flex-col">
+							<span className="text-xs text-gray-400 uppercase">
+								Tipo de Alcance
+							</span>
+							<span className="text-lg font-semibold text-amber-200">
+								{item.weapon_range}
+							</span>
+						</div>
+					)}
+				</CardContent>
+			</Card>
+
+			{/* Properties */}
+			{item.properties && item.properties.length > 0 && (
+				<Card className="bg-dark-card border-dark-border">
+					<CardHeader>
+						<CardTitle className="text-amber-100">Propiedades</CardTitle>
+					</CardHeader>
+					<CardContent>
+						<div className="flex flex-wrap gap-2">
+							{item.properties.map((prop: any, idx: number) => (
+								<Badge
+									key={idx}
+									variant="outline"
+									className="bg-amber-950/30 border-amber-600/30 text-amber-300"
+								>
+									{prop.name || prop}
+								</Badge>
+							))}
+						</div>
+					</CardContent>
+				</Card>
+			)}
+
+			{/* Description */}
+			{item.desc && item.desc.length > 0 && (
+				<Card className="bg-dark-card border-dark-border">
+					<CardHeader>
+						<CardTitle className="text-amber-100">Descripción</CardTitle>
+					</CardHeader>
+					<CardContent className="space-y-3">
+						{(Array.isArray(item.desc) ? item.desc : [item.desc]).map(
+							(paragraph: string, idx: number) => (
+								<p key={idx} className="text-sm text-gray-300 leading-relaxed">
+									{paragraph}
+								</p>
+							),
+						)}
+					</CardContent>
+				</Card>
+			)}
+		</div>
+	);
+};
+
+export default ObjetosDetalleScene;

--- a/frontend/src/scenes/objetos.scene.tsx
+++ b/frontend/src/scenes/objetos.scene.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -318,11 +318,11 @@ export const ObjetosScene = () => {
 					</div>
 
 					<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-						{paginatedItems.map((item) => (
+						{paginatedItems.map((item) =>
+							selectMode ? (
 							<div
 								key={item.id}
 								onClick={() => {
-									if (selectMode) {
 										navigate(`/editar-campana/${campaignId}`, {
 											state: {
 												selectedEntity: {
@@ -334,13 +334,8 @@ export const ObjetosScene = () => {
 												sceneId,
 											},
 										});
-									}
 								}}
-								className={
-									selectMode
-										? "cursor-pointer transition-transform hover:scale-[1.02]"
-										: ""
-								}
+								className="cursor-pointer transition-transform hover:scale-[1.02]"
 							>
 								<Card className="bg-dark-card border-dark-border hover:border-amber-600/50 transition-all duration-300 hover:shadow-lg hover:shadow-amber-600/10 h-full">
 									<CardHeader>
@@ -471,8 +466,131 @@ export const ObjetosScene = () => {
 									</CardContent>
 								</Card>
 							</div>
-						))}
-					</div>
+					) : (
+						<Link
+							key={item.id}
+							to={`/objetos/${item.id}`}
+							className="block transition-transform hover:scale-[1.02]"
+						>
+							<Card className="bg-dark-card border-dark-border hover:border-amber-600/50 transition-all duration-300 hover:shadow-lg hover:shadow-amber-600/10 h-full">
+								<CardHeader>
+									<div className="flex items-start justify-between gap-2">
+										<div className="flex-1 min-w-0">
+											<CardTitle className="text-amber-100 truncate">
+												{item.name}
+											</CardTitle>
+											{item.equipment_category && (
+												<div className="mt-1">
+													<Badge
+														className={`${getCategoryColor(item.equipment_category)} text-white text-xs`}
+													>
+														{typeof item.equipment_category === "object"
+															? item.equipment_category.name
+															: item.equipment_category}
+													</Badge>
+												</div>
+											)}
+										</div>
+									</div>
+								</CardHeader>
+								<CardContent className="space-y-3">
+									<div className="grid grid-cols-2 gap-2 text-sm">
+										{item.cost && (
+											<div className="flex flex-col">
+												<span className="text-gray-400 text-xs">Coste:</span>
+												<span className="text-gray-200 font-semibold">
+													{formatCost(item.cost)}
+												</span>
+											</div>
+										)}
+										{item.weight !== undefined && (
+											<div className="flex flex-col">
+												<span className="text-gray-400 text-xs">Peso:</span>
+												<span className="text-gray-200 font-semibold">
+													{item.weight} lb
+												</span>
+											</div>
+										)}
+									</div>
+									{item.damage && (
+										<div className="space-y-1">
+											<div className="flex items-center justify-between text-sm">
+												<span className="text-gray-400">Daño:</span>
+												<span className="text-gray-200 font-semibold">
+													{item.damage.damage_dice}{" "}
+													{item.damage.damage_type?.name || ""}
+												</span>
+											</div>
+											{item.two_handed_damage && (
+												<div className="flex items-center justify-between text-sm">
+													<span className="text-gray-400">Daño (2 manos):</span>
+													<span className="text-gray-200 font-semibold">
+														{item.two_handed_damage.damage_dice}
+													</span>
+												</div>
+											)}
+										</div>
+									)}
+									{item.armor_class && (
+										<div className="space-y-1">
+											<div className="flex items-center justify-between text-sm">
+												<span className="text-gray-400">CA:</span>
+												<span className="text-gray-200 font-semibold">
+													{typeof item.armor_class === "object"
+														? item.armor_class.base ||
+															item.armor_class.value ||
+															JSON.stringify(item.armor_class)
+														: item.armor_class}
+												</span>
+											</div>
+											{item.str_minimum && (
+												<div className="flex items-center justify-between text-sm">
+													<span className="text-gray-400">FUE mínima:</span>
+													<span className="text-gray-200 font-semibold">
+														{item.str_minimum}
+													</span>
+												</div>
+											)}
+										</div>
+									)}
+									{item.range && (
+										<div className="flex items-center justify-between text-sm">
+											<span className="text-gray-400">Alcance:</span>
+											<span className="text-gray-200 font-semibold">
+												{typeof item.range === "object" &&
+												item.range.normal !== undefined
+													? `${item.range.normal} ft${item.range.long ? ` / ${item.range.long} ft` : ""}`
+													: typeof item.range === "string" ||
+														  typeof item.range === "number"
+														? item.range
+														: "N/A"}
+											</span>
+										</div>
+									)}
+									{item.properties && item.properties.length > 0 && (
+										<div className="flex flex-wrap gap-1 mt-2">
+											{item.properties.map((prop: any, idx: number) => (
+												<Badge
+													key={idx}
+													variant="outline"
+													className="bg-amber-950/30 border-amber-600/30 text-amber-300 text-xs"
+												>
+													{prop.name || prop}
+												</Badge>
+											))}
+										</div>
+									)}
+									{item.desc && item.desc.length > 0 && (
+										<p className="text-xs text-gray-400 italic mt-2 line-clamp-2">
+											{Array.isArray(item.desc) ? item.desc[0] : item.desc}
+										</p>
+									)}
+								</CardContent>
+							</Card>
+						</Link>
+					)
+				)}
+				</div>
 
 					{/* Pagination */}
 					<div className="flex flex-col sm:flex-row items-center justify-between gap-3 mt-4">


### PR DESCRIPTION
- Backend: new GET /api/compendium-items/:id endpoint (accepts UUID or SRD slug)
- Frontend: fetchItemById() in backend.service.ts
- Frontend: new route /objetos/:id and ObjetosDetalleScene
- Frontend: objetos.scene.tsx cards link to detail page (non-selectMode)
- Frontend: inventario.scene.tsx links updated to /objetos/:srdIndex
- Frontend: BagSection and ConsumableSection links updated to /objetos/:srdIndex
- Frontend: back button navigates to /objetos instead of navigate(-1)