### PR TITLE
feat: replace hCaptcha with Cloudflare Turnstile

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,7 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
-        "@hcaptcha/react-hcaptcha": "^2.0.2",
+        "@marsidev/react-turnstile": "^1.5.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -981,12 +981,6 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
-    "node_modules/@hcaptcha/react-hcaptcha": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@hcaptcha/react-hcaptcha/-/react-hcaptcha-2.0.2.tgz",
-      "integrity": "sha512-VbuH6VJ6m3BHmVBHs0fL9t+suZd7PQEqCzqL2BiUbBvbHI3XfvSgdiug2QiEPN8zskbPTIV/FfGPF53JCckrow==",
-      "license": "MIT"
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1083,6 +1077,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@marsidev/react-turnstile": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@marsidev/react-turnstile/-/react-turnstile-1.5.2.tgz",
+      "integrity": "sha512-+3aBPxp86JzSC0ZmgyonoGoUEENcUkH3LGahXSpkV87ArvD2DzRCmPgh0FyQk6PQRmJwQJDAfwNavFsxUxMQWA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.2 || ^18.0.0 || ^19.0",
+        "react-dom": "^17.0.2 || ^18.0.0 || ^19.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@hcaptcha/react-hcaptcha": "^2.0.2",
+    "@marsidev/react-turnstile": "^1.5.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/frontend/src/core/auth/supabaseAuth.ts
+++ b/frontend/src/core/auth/supabaseAuth.ts
@@ -18,7 +18,7 @@ export function mapSupabaseError(msg?: string) {
     return "La contraseña no cumple la longitud mínima.";
   if (m.includes("invalid email")) return "El email no es válido.";
   if (m.includes("captcha"))
-    return "Error de captcha: la site key y el secret deben pertenecer a la misma cuenta de hCaptcha. Revisa la configuración en Supabase.";
+    return "Error de captcha. Revisa la configuración del captcha en Supabase.";
 
   return msg || "Ha ocurrido un error inesperado.";
 }

--- a/frontend/src/interfaces/registerProps.tsx
+++ b/frontend/src/interfaces/registerProps.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from "react";
-import type HCaptcha from "@hcaptcha/react-hcaptcha";
+import type { TurnstileInstance } from "@marsidev/react-turnstile";
 import type { FormErrors, FormData } from "./forms";
 
 export interface RegisterComponentProps {
@@ -7,7 +7,7 @@ export interface RegisterComponentProps {
   errors: FormErrors;
   loading: boolean;
   successMessage?: string | null;
-  captchaRef: RefObject<HCaptcha | null>;
+  captchaRef: RefObject<TurnstileInstance | null>;
   onChange: (field: keyof FormData, value: string | boolean) => void;
   onSubmit: (e: React.FormEvent) => void;
   onGoogleSignIn: () => void;

--- a/frontend/src/pods/login/login.component.tsx
+++ b/frontend/src/pods/login/login.component.tsx
@@ -1,6 +1,6 @@
 import { type RefObject } from "react";
 import { Link } from "react-router";
-import HCaptcha from "@hcaptcha/react-hcaptcha";
+import { Turnstile, type TurnstileInstance } from "@marsidev/react-turnstile";
 import { routes } from "@/router";
 import { useTranslation } from "@/i18n";
 
@@ -13,7 +13,7 @@ interface LoginProps {
   formData: FormData;
   loading: boolean;
   error: string | null;
-  captchaRef: RefObject<HCaptcha | null>;
+  captchaRef: RefObject<TurnstileInstance | null>;
   emailNotConfirmed: boolean;
   resendLoading: boolean;
   resendSuccess: boolean;
@@ -172,12 +172,12 @@ export const LoginComponent = ({
                 </a>
               </div>
 
-              {/* hCaptcha (only in production) */}
+              {/* Turnstile (only in production) */}
               {!import.meta.env.DEV && (
-                <HCaptcha
+                <Turnstile
                   ref={captchaRef}
-                  sitekey={import.meta.env.VITE_HCAPTCHA_SITE_KEY}
-                  size="invisible"
+                  siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
+                  options={{ size: "invisible" }}
                 />
               )}
 

--- a/frontend/src/pods/login/login.container.tsx
+++ b/frontend/src/pods/login/login.container.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useNavigate, useLocation } from "react-router";
-import type HCaptcha from "@hcaptcha/react-hcaptcha";
+import { type TurnstileInstance } from "@marsidev/react-turnstile";
 import { LoginComponent } from "./login.component";
 import { routes } from "@/router";
 import { signIn, signInWithGoogle, resendSignUpConfirmation } from "@/core/auth/supabaseAuth";
@@ -13,7 +13,7 @@ interface FormData {
 export const LoginContainer = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
-	const captchaRef = useRef<HCaptcha>(null);
+	const captchaRef = useRef<TurnstileInstance>(null);
 
 	const [formData, setFormData] = useState<FormData>({
 		email: (location.state as { email?: string })?.email || "",
@@ -44,11 +44,11 @@ export const LoginContainer = () => {
 		setLoading(true);
 		try {
 			const isDev = import.meta.env.DEV;
-			const captchaToken = isDev ? undefined : await captchaRef.current?.execute({ async: true });
-			await signIn(formData.email, formData.password, captchaToken?.response);
+			const captchaToken = isDev ? undefined : await captchaRef.current?.getResponsePromise();
+			await signIn(formData.email, formData.password, captchaToken);
 			navigate(routes.profileCampanas);
 		} catch (err) {
-			captchaRef.current?.resetCaptcha();
+			captchaRef.current?.reset();
 			const msg = err instanceof Error ? err.message : "Error desconocido";
 			if (msg.toLowerCase().includes("confirmar tu email")) {
 				setEmailNotConfirmed(true);

--- a/frontend/src/pods/register/register.component.tsx
+++ b/frontend/src/pods/register/register.component.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router";
-import HCaptcha from "@hcaptcha/react-hcaptcha";
+import { Turnstile } from "@marsidev/react-turnstile";
 import { routes } from "@/router";
 import type { RegisterComponentProps } from "@/interfaces/registerProps";
 import { useTranslation } from "@/i18n";
@@ -198,12 +198,12 @@ export const RegisterComponent = ({
                 {errors.terms && <p className="mt-1 text-sm text-error">{errors.terms}</p>}
               </div>
 
-              {/* hCaptcha (only in production) */}
+              {/* Turnstile (only in production) */}
               {!import.meta.env.DEV && (
-                <HCaptcha
+                <Turnstile
                   ref={captchaRef}
-                  sitekey={import.meta.env.VITE_HCAPTCHA_SITE_KEY}
-                  size="invisible"
+                  siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
+                  options={{ size: "invisible" }}
                 />
               )}
 

--- a/frontend/src/pods/register/register.container.tsx
+++ b/frontend/src/pods/register/register.container.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router";
-import type HCaptcha from "@hcaptcha/react-hcaptcha";
+import { type TurnstileInstance } from "@marsidev/react-turnstile";
 import { RegisterComponent } from "./register.component";
 import { routes } from "@/router";
 import type { FormData, FormErrors } from "@/interfaces/forms";
@@ -8,7 +8,7 @@ import { resendSignUpConfirmation, signUp, signInWithGoogle } from "@/core/auth/
 
 export const RegisterContainer = () => {
   const navigate = useNavigate();
-  const captchaRef = useRef<HCaptcha>(null);
+  const captchaRef = useRef<TurnstileInstance>(null);
   const [formData, setFormData] = useState<FormData>({
     username: "",
     displayName: "",
@@ -63,13 +63,13 @@ export const RegisterContainer = () => {
 
     try {
       const isDev = import.meta.env.DEV;
-      const captchaToken = isDev ? undefined : await captchaRef.current?.execute({ async: true });
+      const captchaToken = isDev ? undefined : await captchaRef.current?.getResponsePromise();
       await signUp({
         email: formData.email,
         username: formData.username,
         password: formData.password,
         displayName: formData.displayName || formData.username,
-        captchaToken: captchaToken?.response,
+        captchaToken,
       });
 
       setSuccess(
@@ -80,7 +80,7 @@ export const RegisterContainer = () => {
         2000
       );
     } catch (error) {
-      captchaRef.current?.resetCaptcha();
+      captchaRef.current?.reset();
       const message =
         error instanceof Error ? error.message : "Error al registrar usuario.";
 


### PR DESCRIPTION
Sustituye hCaptcha por Cloudflare Turnstile como captcha en login y registro.

**Cambios**:
- Elimina @hcaptcha/react-hcaptcha
- Anade @marsidev/react-turnstile
- Reemplaza widget y logica en login y register (component + container)
- Actualiza tipos en registerProps.tsx
- Actualiza mensaje de error en supabaseAuth.ts
- Cambia env var de VITE_HCAPTCHA_SITE_KEY a VITE_TURNSTILE_SITE_KEY