### PR TITLE
fix(backend): 502 en /api — node --env-file falla en imagen GHCR

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+.env
+node_modules

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
 	"type": "module",
 	"main": "src/index.js",
 	"scripts": {
-		"start": "node --env-file=.env src/index.js"
+		"start": "node src/index.js"
 	},
 	"dependencies": {
 		"express": "^4.19.2",


### PR DESCRIPTION
## Problema

Todas las rutas `/api/*` devuelven **502 Bad Gateway** desde el deploy con imágenes GHCR.

### Causa raíz

El script de inicio era `node --env-file=.env src/index.js`. Este flag hace que Node.js lea un **fichero** `.env` en `/app/.env` dentro del contenedor.

- **Build local en VPS** (antes): `COPY . .` copiaba el `.env` dentro de la imagen → ✓  
- **Imagen GHCR** (ahora): la imagen se construye en CI sin `.env` → el fichero no existe → **Node crashea al arrancar → 502** ✗

`docker-compose.prod.yml` ya usa `env_file: ./backend/.env` que inyecta todas las variables en `process.env`. El backend usa `process.env.*` en todo el código, por lo que `node src/index.js` es suficiente.

## Cambios

- `backend/package.json`: quitar `--env-file=.env` del start script  
- `backend/.dockerignore`: excluir `.env` y `node_modules` de la imagen

## Test plan

- [ ] CI verde
- [ ] Tras deploy, `GET /api/character-sheets` devuelve 200 en vez de 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)